### PR TITLE
added error handling for plugin init

### DIFF
--- a/src/core/utils/plugin.js
+++ b/src/core/utils/plugin.js
@@ -103,7 +103,12 @@ class Plugin
 
 		if (this.initFunc)
 		{
-			await this.initFunc();
+			try {
+				await this.initFunc();
+			} catch (err) {
+				// TODO: Throw exception to UI
+				console.log(`Error loading ${this.name} plugin. Error Msg: ${err}.`)
+			}
 		}
 	}
 


### PR DESCRIPTION
Closes #5. Next, errors need to be handled in the UI.