### PR TITLE
Fix Channel Point Rewards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "castmate",
-  "version": "0.3.1",
+  "version": "0.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "castmate",
-      "version": "0.3.1",
+      "version": "0.3.3",
       "hasInstallScript": true,
       "dependencies": {
         "@peter-murray/hue-bridge-model": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "castmate",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": "true",
   "description": "CastMate is a broadcaster tool that allows Twitch viewers to interact with a broadcasters stream components through Chat Commands, Channel Point rewards, and more.",
   "author": "LordTocs & FitzBro",

--- a/src/main/actions/profile-manager.js
+++ b/src/main/actions/profile-manager.js
@@ -73,10 +73,11 @@ export class ProfileManager
 			}
 
 			await newProfile.saveConfig(finalConfig);
-			await this.handleProfileLoaded(newProfile);
 
 			this.profiles.push(newProfile);
 
+			await this.handleProfileLoaded(newProfile);
+			
 			return true;
 		});
 		ipcFunc("io", "deleteProfile", async(name) => {

--- a/src/main/actions/profile-manager.js
+++ b/src/main/actions/profile-manager.js
@@ -61,16 +61,18 @@ export class ProfileManager
 				this.handleProfileLoaded(profile);
 			});
 
-			if (!config)
-			{
-				config = {
-					version: "2.0",
-					triggers: {},
-					conditions: { operator: 'any', operands: [] }
-				}
+			const finalConfig = {
+				version: "2.0",
+				triggers: {},
+				conditions: { operator: 'any', operands: [] }
 			}
 
-			await newProfile.saveConfig(config);
+			if (config)
+			{
+				Object.assign(finalConfig, config);
+			}
+
+			await newProfile.saveConfig(finalConfig);
 			await this.handleProfileLoaded(newProfile);
 
 			this.profiles.push(newProfile);

--- a/src/main/actions/profile-manager.js
+++ b/src/main/actions/profile-manager.js
@@ -26,6 +26,8 @@ export class ProfileManager
 
 		this.ipcSender = ipcSender;
 
+		this.recombiner = null;
+
 		ipcMain.handle("core_getActiveProfiles", () => this.activeProfiles.map(p => p.name));
 
 		this.createIOFuncs();
@@ -204,11 +206,22 @@ export class ProfileManager
 			// Deactivate the old watcher if it exists.
 			profile.watcher.unsubscribe();
 		}
-		profile.watcher = new Watcher(() => this.recombine(), { fireImmediately: false });
+		profile.watcher = new Watcher(() => this.markForRecombine(), { fireImmediately: false });
 		dependOnAllConditions(profile.conditions, this.plugins.stateLookup, profile.watcher);
 		
 		// Recombine active profiles 
 		this.recombine();
+	}
+
+	markForRecombine() {
+		if (this.recombiner)
+		{
+			return;
+		}
+		this.recombiner = setTimeout(() => {
+			this.recombiner = null;
+			this.recombine();
+		}, 100);
 	}
 
 	//Recalculate which profiles are active.

--- a/src/main/background.js
+++ b/src/main/background.js
@@ -3,7 +3,7 @@ const isDevelopment = import.meta.env.DEV
 import { fileURLToPath } from 'node:url'
 import { createRequire } from 'node:module'
 const require = createRequire(import.meta.url)
-const { app, shell, ipcMain, BrowserWindow } = require('electron');
+const { app, shell, ipcMain, BrowserWindow, dialog } = require('electron');
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -12,6 +12,7 @@ import installExtension, { VUEJS_DEVTOOLS } from 'electron-devtools-installer';
 import electronUpdater from 'electron-updater';
 const { autoUpdater, CancellationToken } = electronUpdater;
 import path from 'path'
+import util from 'util'
 
 import { initCastMate } from './castmate.js';
 
@@ -139,7 +140,17 @@ ipcMain.handle("windowFuncs_getVersion", async () => {
 
 ipcMain.handle("updater.downloadUpdate", async () => {
 	updateContext.cancelToken = new CancellationToken();
-	await autoUpdater.downloadUpdate(updateContext.cancelToken);
+	try
+	{
+		await autoUpdater.downloadUpdate(updateContext.cancelToken);
+	}
+	catch(err) {
+		dialog.showMessageBoxSync({
+			message: `${util.inspect(err)}`,
+			type: "error",
+			title: "ERROR UPDATING CASTMATE"
+		})
+	}
 	updateContext.cancelToken = null;
 });
 

--- a/src/main/plugins/twitch.js
+++ b/src/main/plugins/twitch.js
@@ -551,7 +551,18 @@ export default {
 				return;
 			}
 
-			this.rewards = await this.channelTwitchClient.channelPoints.getCustomRewards(this.channelId, true);
+			this.rewards = (await this.channelTwitchClient.channelPoints.getCustomRewards(this.channelId, true)).map(r => ({
+				id: r.id,
+				title: r.title,
+				backgroundColor: r.backgroundColor,
+				prompt: r.prompt,
+				cost: r.cost,
+				userInputRequired: r.userInputRequired,
+				autoFulfill: r.autoFulfill,
+				maxRedemptionsPerStream: r.maxRedemptionsPerStream,
+				maxRedemptionsPerUserPerStream: r.maxRedemptionsPerUserPerStream,
+				isEnabled: r.isEnabled
+			}));
 			this.logger.info(`Got rewards, ${this.rewards.length}`)
 		},
 
@@ -559,12 +570,19 @@ export default {
 			if (!this.channelId || !this.state.isAffiliate)
 				return;
 
+			//console.log("Switch Rewards")
+			//console.log("Active", activeRewards)
+			//console.log("Inactive", inactiveRewards)
+
 			for (let reward of this.rewards) {
+				//console.log("Reward: ", reward.title, ":", reward.isEnabled ,":", activeRewards.has(reward.title), inactiveRewards.has(reward.title))
 				if (!reward.isEnabled && activeRewards.has(reward.title)) {
 					await this.channelTwitchClient.channelPoints.updateCustomReward(this.channelId, reward.id, { isPaused: false, isEnabled: true });
+					reward.isEnabled = true;
 				}
 				else if (reward.isEnabled && inactiveRewards.has(reward.title)) {
 					await this.channelTwitchClient.channelPoints.updateCustomReward(this.channelId, reward.id, { isPaused: false, isEnabled: false });
+					reward.isEnabled = false;
 				}
 			}
 		}

--- a/src/main/utils/electronBridge.js
+++ b/src/main/utils/electronBridge.js
@@ -7,6 +7,7 @@ export const app = electron.app
 export const ipcMain = electron.ipcMain
 export const BrowserWindow = electron.BrowserWindow
 export const safeStorage = electron.safeStorage
+export const dialog = electron.dialog
 
 
 


### PR DESCRIPTION
Channel Point Rewards weren't enabling and disabling properly due to their state being pulled in from the twitch servers.

We properly update our local state now to avoid issues.

We also now wait 100ms before triggering a profile recombine incase multiple profiles are changing based on state changes.